### PR TITLE
Consider waiting units (timers) to be running

### DIFF
--- a/pyinfra/facts/init.py
+++ b/pyinfra/facts/init.py
@@ -41,7 +41,8 @@ class SystemdStatus(FactBase):
             line = line.strip()
             matches = re.match(self.regex, line)
             if matches:
-                services[matches.group(1)] = matches.group(2) == 'running'
+                services[matches.group(1)] = matches.group(2) == 'running' or\
+                                             matches.group(2) == 'waiting'
 
         return services
 


### PR DESCRIPTION
If you specify a systemd timer unit to be running, pyinfra always tries to start the timer, even though it is already active.
This PR fixes that behavior.